### PR TITLE
Resize mode parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__
 output/*
 *.zip
+/.vs
+/env

--- a/README.MD
+++ b/README.MD
@@ -245,18 +245,15 @@ Here is a resized image (200x200), but with the boundies box drawed:
 ## Parameters
 To know more about parameters use `python main.py -h`:
 ```
-usage: main.py [-h] -p DATASET_PATH -o OUTPUT_PATH -x X -y Y
-               [-s SAVE_BOX_IMAGES]
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -p DATASET_PATH, --path DATASET_PATH
-                        Path to dataset data ?(image and annotations).
-  -o OUTPUT_PATH, --output OUTPUT_PATH
-                        Path that will be saved the resized dataset
-  -x X, --new_x X       The new x images size
-  -y Y, --new_y Y       The new y images size
-  -s SAVE_BOX_IMAGES, --save_box_images SAVE_BOX_IMAGES
-                        If True, it will save the resized image and a drawed
-                        image with the boxes in the images
+usage: main.py [-h] -p DATASET_PATH -o OUTPUT_PATH -x X -y Y [-m MODE] [-s SAVE_BOX_IMAGES]
 ```
+
+Parameter|Description
+-|-
+  **-h**, **--help** | Show this help message and exit
+  **-p** **--path** *DATASET_PATH* | Path to dataset data ?(image and annotations).
+  **-o** **--output** *OUTPUT_PATH* | Path that will be saved the resized dataset
+  **-x** **--new_x** *X* | The new x images size / scale / percentage / target
+  **-y** **--new_y** *Y* | The new y images size / scale / percentage / target
+  **-m** **--mode** *MODE* | The resize mode: size, scale, percentage or target
+  **-s** **--save_box_images** *SAVE_BOX_IMAGES* | If True, it will save the resized image and a drawn image with the boxes in the images

--- a/image.py
+++ b/image.py
@@ -6,7 +6,7 @@ import xml.etree.ElementTree as ET
 from math import floor
 
 
-def process_image(file_path, output_path, x, y, save_box_images, ratio):
+def process_image(file_path, output_path, x, y, save_box_images, mode):
     (base_dir, file_name, ext) = get_file_name(file_path)
     image_path = '{}/{}.{}'.format(base_dir, file_name, ext)
     xml = '{}/{}.xml'.format(base_dir, file_name)
@@ -16,7 +16,7 @@ def process_image(file_path, output_path, x, y, save_box_images, ratio):
             xml,
             (x, y),
             output_path,
-            ratio,
+            mode,
             save_box_images=save_box_images
         )
     except Exception as e:
@@ -34,24 +34,47 @@ def resize(image_path,
            xml_path,
            newSize,
            output_path,
-           ratio,
+           mode,
            save_box_images=False,
            verbose=False
            ):
 
     image = cv2.imread(image_path)
 
-    if ratio is None:
-        scale_x = newSize[0] / image.shape[1]
-        scale_y = newSize[1] / image.shape[0]
-    
+    mode = mode and mode.lower()
+    # Standard resize mode
+    if mode is None or mode == 'size':
+        newSize = (int(newSize[0]), int(newSize[1]))
+        scale_x = float(newSize[0]) / float(image.shape[1])
+        scale_y = float(newSize[1]) / float(image.shape[0])
+        image = cv2.resize(src=image, dsize=(newSize[0], newSize[1]))
     else:
-        newSize[0] = floor(image.shape[1] * newSize[0])
-        newSize[1] = floor(image.shape[0] * newSize[0])
-        scale_x = newSize[0] / image.shape[1]
-        scale_y = newSize[1] / image.shape[0]
-
-    image = cv2.resize(image, (newSize[0], newSize[1]))
+        # Scaling by factor or percentage of the original image size
+        if mode == 'scale' or mode == 'percentage':
+            mul = 0.01 if mode == 'percentage' else 1.0
+            newSize = (
+                floor(float(image.shape[1]) * float(newSize[0]) * mul),
+                floor(float(image.shape[0]) * float(newSize[1]) * mul))
+            scale_x = newSize[0] / image.shape[1]
+            scale_y = newSize[1] / image.shape[0]
+            interp = cv2.INTER_LINEAR if (scale_x > 1.0 or scale_y > 1.0) else cv2.INTER_AREA
+            image = cv2.resize(
+                src=image,
+                dsize=(0, 0), dst=None,
+                fx=scale_x, fy=scale_y, interpolation=interp)
+        # Target mode; choose the correct ratio to reach one of the x/y targets without oversize
+        elif mode == 'target':
+            ratio = float(int(newSize[0])) / float(image.shape[1])
+            targetRatio = float(int(newSize[1])) / float(image.shape[0])
+            ratio = targetRatio if targetRatio < ratio else ratio
+            scale_x = scale_y = ratio
+            interp = cv2.INTER_LINEAR if (scale_x > 1.0 or scale_y > 1.0) else cv2.INTER_AREA
+            image = cv2.resize(
+                src=image,
+                dsize=(0, 0), dst=None,
+                fx=scale_x, fy=scale_y, interpolation=interp)
+        else:
+            raise Exception(f"Invalid resize mode: {mode}")
 
     newBoxes = []
     xmlRoot = ET.parse(xml_path).getroot()

--- a/main.py
+++ b/main.py
@@ -25,22 +25,22 @@ parser.add_argument(
     '-x',
     '--new_x',
     dest='x',
-    help='The new x images size',
+    help='The new x images size / scale / percentage / target',
     required=True
 )
 parser.add_argument(
     '-y',
     '--new_y',
     dest='y',
-    help='The new y images size',
+    help='The new y images size / scale / percentage / target',
     required=True
 )
 
 parser.add_argument(
-    '-r',
-    '--ratio',
-    dest='ratio',
-    help='If new sizes are ratio instead of definite size',
+    '-m',
+    '--mode',
+    dest='mode',
+    help='Resize mode: size, scale, percentage or target',
     required=False
 )
 
@@ -70,4 +70,4 @@ for root, _, files in os.walk(args.dataset_path):
         for file in files:
             if file.endswith(IMAGE_FORMATS):
                 file_path = os.path.join(root, file)
-                process_image(file_path, output_path, int(args.x),int(args.y), args.save_box_images, args.ratio)
+                process_image(file_path, output_path, args.x, args.y, args.save_box_images, args.mode)


### PR DESCRIPTION
Added the resize mode function by --mode paramete.
It's possible to choose between 4 modes:

- size (default): image shrink / grow to the specified size parameters.
- scale: --new_x / --new_y are interpreted as scale factors.
- percentage: --new_x / --new_y are interpreted as percentages.
- target: --new_x / --new_y are interpreted as targets for the new images. The algorithm will choose the best ratio for reaching one of the targets without ecceeding the other (shrinking or growing).
